### PR TITLE
Implement a simple callback when complete

### DIFF
--- a/js/github.commits.widget.js
+++ b/js/github.commits.widget.js
@@ -1,7 +1,8 @@
 (function ($) {
-	function widget(element, options) {
+	function widget(element, options, callback) {
 		this.element = element;
 		this.options = options;
+		this.callback = $.isFunction(callback) ? callback : $.noop;
 	}
 	
 	widget.prototype = (function() {
@@ -11,7 +12,7 @@
 				widget.element.append('<span class="error">Options for widget are not set.</span>');
 				return;
 			}
-		
+		        var callback = widget.callback;
 			var element = widget.element;
 			var user = widget.options.user;
 			var repo = widget.options.repo;
@@ -38,6 +39,7 @@
 				}
 				element.append('</ul>');
 				element.append('<br/><h5>by <a href="https://github.com/alexanderbeletsky/github.commits.widget">github.commits.widget</a></h5>');
+				callback(element);
 				
 				function avatar(email) {
 					var emailHash = hex_md5(email);
@@ -89,8 +91,8 @@
 		
 	})();
 
-	$.fn.githubInfoWidget = function(options) {
-		var w = new widget(this, options);
+	$.fn.githubInfoWidget = function(options, callback) {
+		var w = new widget(this, options, callback);
 		w.run();
 		
 		return this;


### PR DESCRIPTION
Assuming I tested correctly (please verify), there is now an optional third argument to `githubInfoWidget` that can take a function with one parameter (being the element to which the commit history was added)
