### PR TITLE
Three commits

### DIFF
--- a/cnm.bat
+++ b/cnm.bat
@@ -2,5 +2,5 @@ echo off
 echo Combining and minifying .js files...
 
 cd ./js/
-"D:\Program Files\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m combine github.js md5.js github.commits.widget.js
-"D:\Program Files\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m jsmin github.commits.widget-min.js
+"%PROGRAMFILES(X86)%\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m combine github.js md5.js github.commits.widget.js
+"%PROGRAMFILES(X86)%\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m jsmin github.commits.widget-min.js

--- a/cnm.bat
+++ b/cnm.bat
@@ -1,6 +1,12 @@
-echo off
+@echo off
 echo Combining and minifying .js files...
 
+IF EXIST "%ProgramFiles(x86)%" (
+ set PACKER="%PROGRAMFILES(X86)%\SmallSharpTools\Packer for .NET\bin\Packer.exe"
+) ELSE (
+ set PACKER="%PROGRAMFILES%\SmallSharpTools\Packer for .NET\bin\Packer.exe"
+)
+
 cd ./js/
-"%PROGRAMFILES(X86)%\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m combine github.js md5.js github.commits.widget.js
-"%PROGRAMFILES(X86)%\SmallSharpTools\Packer for .NET\bin\Packer.exe" -o github.commits.widget-min.js -m jsmin github.commits.widget-min.js
+%PACKER% -o github.commits.widget-min.js -m combine github.js md5.js github.commits.widget.js
+%PACKER% -o github.commits.widget-min.js -m jsmin github.commits.widget-min.js

--- a/js/github.commits.widget-min.js
+++ b/js/github.commits.widget-min.js
@@ -106,16 +106,16 @@ function safe_add(x,y)
 {var lsw=(x&0xFFFF)+(y&0xFFFF);var msw=(x>>16)+(y>>16)+(lsw>>16);return(msw<<16)|(lsw&0xFFFF);}
 function bit_rol(num,cnt)
 {return(num<<cnt)|(num>>>(32-cnt));}
-(function($){function widget(element,options){this.element=element;this.options=options;}
+(function($){function widget(element,options,callback){this.element=element;this.options=options;this.callback=$.isFunction(callback)?callback:$.noop;}
 widget.prototype=(function(){function _widgetRun(widget){if(!widget.options){widget.element.append('<span class="error">Options for widget are not set.</span>');return;}
-var element=widget.element;var user=widget.options.user;var repo=widget.options.repo;var branch=widget.options.branch;var last=widget.options.last==undefined?0:widget.options.last;var limitMessage=widget.options.limitMessageTo==undefined?0:widget.options.limitMessageTo;element.append('<h3>Widget intitalization, please wait...</h3>');gh.commit.forBranch(user,repo,branch,function(data){var commits=data.commits;var totalCommits=(last<commits.length?last:commits.length);element.empty();element.append('<ul>');for(var c=0;c<totalCommits;c++){element.append('<li>'+' '+avatar(commits[c].author.email)+' '+author(commits[c].author.login)+' commited '+message(commits[c].message,commits[c].url)+' '+when(commits[c].committed_date)+'</li>');}
-element.append('</ul>');element.append('<br/><h5>by <a href="https://github.com/alexanderbeletsky/github.commits.widget">github.commits.widget</a></h5>');function avatar(email){var emailHash=hex_md5(email);return'<img src="http://www.gravatar.com/avatar/'+emailHash+'?s=20"/>';}
-function author(login){return'<a href="https://github.com/'+login+'">'+login+'</a>';}
+var callback=widget.callback;var element=widget.element;var user=widget.options.user;var repo=widget.options.repo;var branch=widget.options.branch;var avatarSize=widget.options.avatarSize||20;var last=widget.options.last==undefined?0:widget.options.last;var limitMessage=widget.options.limitMessageTo==undefined?0:widget.options.limitMessageTo;element.append('<p>Widget intitalization, please wait...</p>');gh.commit.forBranch(user,repo,branch,function(data){var commits=data.commits;var totalCommits=(last<commits.length?last:commits.length);element.empty();var list=$('<ul>').appendTo(element);for(var c=0;c<totalCommits;c++){list.append('<li>'+' '+avatar(commits[c].author.email,avatarSize)+' '+author(commits[c].author.login)+' committed '+message(commits[c].message,commits[c].url)+' '+when(commits[c].committed_date)+'</li>');}
+element.append('<p class="github-commits-widget-by">by <a href="https://github.com/alexanderbeletsky/github.commits.widget">github.commits.widget</a></p>');callback(element);function avatar(email,size){var emailHash=hex_md5(email);return'<img class="github-avatar" src="http://www.gravatar.com/avatar/'+emailHash+'?s='+size+'"/>';}
+function author(login){return'<a class="github-user" href="https://github.com/'+login+'">'+login+'</a>';}
 function message(commitMessage,url){if(limitMessage>0&&commitMessage.length>limitMessage)
 {commitMessage=commitMessage.substr(0,limitMessage)+'...';}
-return'"'+'<a href="https://github.com'+url+'">'+commitMessage+'</a>"';}
+return'"'+'<a class="github-commit" href="https://github.com'+url+'">'+commitMessage+'</a>"';}
 function when(commitDate){var commitTime=new Date(commitDate).getTime();var todayTime=new Date().getTime();var differenceInDays=Math.floor(((todayTime-commitTime)/(24*3600*1000)));if(differenceInDays==0){var differenceInHours=Math.floor(((todayTime-commitTime)/(3600*1000)));if(differenceInHours==0){var differenceInMinutes=Math.floor(((todayTime-commitTime)/(600*1000)));if(differenceInMinutes==0){return'just now';}
 return'about '+differenceInMinutes+' minutes ago';}
 return'about '+differenceInHours+' hours ago';}
 return differenceInDays+' days ago';}});}
-return{run:function(){_widgetRun(this);}};})();$.fn.githubInfoWidget=function(options){var w=new widget(this,options);w.run();return this;}})(jQuery);
+return{run:function(){_widgetRun(this);}};})();$.fn.githubInfoWidget=function(options,callback){var w=new widget(this,options,callback);w.run();return this;}})(jQuery);

--- a/js/github.commits.widget-min.js
+++ b/js/github.commits.widget-min.js
@@ -116,6 +116,6 @@ function message(commitMessage,url){if(limitMessage>0&&commitMessage.length>limi
 return'"'+'<a class="github-commit" href="https://github.com'+url+'">'+commitMessage+'</a>"';}
 function when(commitDate){var commitTime=new Date(commitDate).getTime();var todayTime=new Date().getTime();var differenceInDays=Math.floor(((todayTime-commitTime)/(24*3600*1000)));if(differenceInDays==0){var differenceInHours=Math.floor(((todayTime-commitTime)/(3600*1000)));if(differenceInHours==0){var differenceInMinutes=Math.floor(((todayTime-commitTime)/(600*1000)));if(differenceInMinutes==0){return'just now';}
 return'about '+differenceInMinutes+' minutes ago';}
-return'about '+differenceInHours+' hours ago';}
+return'about '+differenceInHours+' hours ago';}else if(differenceInDays==1){return'yesterday';}
 return differenceInDays+' days ago';}});}
 return{run:function(){_widgetRun(this);}};})();$.fn.githubInfoWidget=function(options,callback){var w=new widget(this,options,callback);w.run();return this;}})(jQuery);

--- a/js/github.commits.widget.js
+++ b/js/github.commits.widget.js
@@ -76,8 +76,9 @@
 						}
 
 						return 'about ' + differenceInHours + ' hours ago';
-					}
-
+					}else if (differenceInDays == 1) {
+                        return 'yesterday';
+                    }
 					return differenceInDays + ' days ago';
 				}
 			});

--- a/js/github.commits.widget.js
+++ b/js/github.commits.widget.js
@@ -21,7 +21,7 @@
 			var last = widget.options.last == undefined ? 0 : widget.options.last;
 			var limitMessage = widget.options.limitMessageTo == undefined ? 0 : widget.options.limitMessageTo;
 
-			element.append('<h3>Widget intitalization, please wait...</h3>');
+			element.append('<p>Widget intitalization, please wait...</p>');
 			gh.commit.forBranch(user, repo, branch, function (data) {
 				var commits = data.commits;
 				var totalCommits = (last < commits.length ? last : commits.length);
@@ -38,7 +38,7 @@
 						' ' + when(commits[c].committed_date) +
 						'</li>');
 				}
-				element.append('<br/><h5>by <a href="https://github.com/alexanderbeletsky/github.commits.widget">github.commits.widget</a></h5>');
+				element.append('<p class="github-commits-widget-by">by <a href="https://github.com/alexanderbeletsky/github.commits.widget">github.commits.widget</a></p>');
 				callback(element);
 
 				function avatar(email, size) {


### PR DESCRIPTION
Hi,

I have three changes for you:
1. Removing header tags from generated html (h3, h4 => p). Removing <br> from the by github.commits.. and wrapping the text in a p. (_I needed it this way to integrate into my website. I could revert this if you'd like._)
2. Commit age '1 day ago' now reads 'yesterday'.
3. The packer batch file should now run on both 64-bit and 32-bit systems without modification (and uses the PROGRAMFILES environment variable.)
