### PR TITLE
Fix repository name in example page.

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
   <script>
 	$(function() {
 		$('#github-commits').githubInfoWidget(
-			{ user: 'alexanderbeletsky', repo: 'github.commits.widget', branch: 'master', last: 15, limitMessageTo: 30 });
+			{ user: 'alexanderbeletsky', repo: 'github-commits-widget', branch: 'master', last: 15, limitMessageTo: 30 });
 	});
   </script>  
 </body>


### PR DESCRIPTION
The example page was resulting in

```
{
  "message": "Not Found"
}
```

from the server and an empty commit list. It might be nicer to have the error message reflected in the UI or at least output to the console, but for now there's this.

Looks like my editor also added a newline at the end of a file. If that's problematic I can reopen.
