### PR TITLE
fixing bower packaging file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,5 +1,5 @@
 {
   "name": "github.commits.widget",
   "version": "0.0.1",
-  "main": "js/github.commits.widget.js",
+  "main": "js/github.commits.widget.js"
 }


### PR DESCRIPTION
`bower install github.commits.widget` complains because of the comma, saying:

```
There were errors, here's a summary of them:
- github.commits.widget Failed to parse json
Unexpected token }
An error was caught when reading the bower.json: Failed to parse json
Unexpected token }
```
